### PR TITLE
Store stock log

### DIFF
--- a/app/controllers/faculties_controller.rb
+++ b/app/controllers/faculties_controller.rb
@@ -1,5 +1,6 @@
 class FacultiesController < ApplicationController
   def index
+    cookies.permanent.signed["uuid"] ||= SecureRandom.uuid
     @faculties = Faculty.all
   end
   

--- a/app/controllers/stock_subjects_controller.rb
+++ b/app/controllers/stock_subjects_controller.rb
@@ -33,7 +33,7 @@ class StockSubjectsController < ApplicationController
         ids "add", subject_id
         uuid = cookies.signed["uuid"]
         if log = StockedLog.find_by(uuid: uuid, subject_id: subject_id)
-          log.update(uuid: uuid, subject_id: subject_id, week: week, periods: period_array)
+          log.update(uuid: uuid, subject_id: subject_id, week: week, periods: period_array, deleted: false)
         else
           StockedLog.create(uuid: uuid, subject_id: subject_id, week: week, periods: period_array)
         end
@@ -50,6 +50,10 @@ class StockSubjectsController < ApplicationController
       if subject_id
         schedules "delete", subject_id
         ids "delete", subject_id
+        uuid = cookies.signed["uuid"]
+        if log = StockedLog.find_by(uuid: uuid, subject_id: subject_id)
+          log.update_attribute(:deleted, true)
+        end
         format.js { @status = {"status": "success", "id": subject_id} }
       else
         format.js { @status = {"status": "fail"} }
@@ -58,6 +62,8 @@ class StockSubjectsController < ApplicationController
   end
   
   def clear
+    uuid = cookies.signed["uuid"]
+    StockedLog.where(subject_id: ids("get")).update_all(deleted: true)
     cookies.delete "subject_schedules"
     cookies.delete "subjects"
     redirect_to stock_subjects_url

--- a/app/controllers/stock_subjects_controller.rb
+++ b/app/controllers/stock_subjects_controller.rb
@@ -72,7 +72,7 @@ class StockSubjectsController < ApplicationController
     elsif method == 'get'
       return cookie_hash
     end
-    cookies["subject_schedules"] = JSON.dump cookie_hash.stringify_keys
+    cookies.permanent["subject_schedules"] = JSON.dump cookie_hash.stringify_keys
   end
   
   def ids(method, data=nil)
@@ -84,6 +84,6 @@ class StockSubjectsController < ApplicationController
     elsif method == 'get'
       return subject_ids
     end
-    cookies["subjects"] = subject_ids
+    cookies.permanent["subjects"] = subject_ids
   end
 end

--- a/app/controllers/stock_subjects_controller.rb
+++ b/app/controllers/stock_subjects_controller.rb
@@ -31,6 +31,12 @@ class StockSubjectsController < ApplicationController
       if week && period_array && subject_id
         schedules "add", [subject_id, [week, period_array]]
         ids "add", subject_id
+        uuid = cookies.signed["uuid"]
+        if log = StockedLog.find_by(uuid: uuid, subject_id: subject_id)
+          log.update(uuid: uuid, subject_id: subject_id, week: week, periods: period_array)
+        else
+          StockedLog.create(uuid: uuid, subject_id: subject_id, week: week, periods: period_array)
+        end
         format.js { @status = {"status": "success", "id": subject_id} }
       else
         format.js { @status = {"status": "fail"} }
@@ -44,7 +50,6 @@ class StockSubjectsController < ApplicationController
       if subject_id
         schedules "delete", subject_id
         ids "delete", subject_id
-        p subject_id
         format.js { @status = {"status": "success", "id": subject_id} }
       else
         format.js { @status = {"status": "fail"} }

--- a/app/models/stocked_log.rb
+++ b/app/models/stocked_log.rb
@@ -1,0 +1,10 @@
+class StockedLog < ApplicationRecord
+  belongs_to :summarized_subject, primary_key: "subject_id", foreign_key: "subject_id"
+  belongs_to :subject
+  
+  validates :uuid, presence: true, length: { maximum: 50 }
+  validates :subject_id, presence: true
+  validates :week, presence: true
+  validates :periods, presence: true
+  validates :uuid, uniqueness: { :scope => [:week, :periods] }
+end

--- a/app/models/stocked_log.rb
+++ b/app/models/stocked_log.rb
@@ -2,9 +2,16 @@ class StockedLog < ApplicationRecord
   belongs_to :summarized_subject, primary_key: "subject_id", foreign_key: "subject_id"
   belongs_to :subject
   
+  before_save :array2str_periods
+  
   validates :uuid, presence: true, length: { maximum: 50 }
   validates :subject_id, presence: true
   validates :week, presence: true
   validates :periods, presence: true
-  validates :uuid, uniqueness: { :scope => [:week, :periods] }
+  validates :uuid, uniqueness: { :scope => [:subject_id] }
+  
+  private
+    def array2str_periods
+      self.periods = periods.gsub(/[\[|\]| |"]/, '')
+    end
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -2,6 +2,7 @@ class Subject < ApplicationRecord
   belongs_to :faculty
   has_many :year_data, dependent: :destroy
   has_one :subject_score
+  has_many :stocked_logs
   
   validates :name, presence: true
   validates :code, presence: true, length: { maximum: 50 }, uniqueness: true

--- a/app/models/summarized_subject.rb
+++ b/app/models/summarized_subject.rb
@@ -2,6 +2,7 @@ class SummarizedSubject < ApplicationRecord
   belongs_to :faculty
   has_many :year_data, primary_key: "subject_id", foreign_key: "subject_id"
   belongs_to :teacher
+  has_many :stocked_logs
   
   validates :name, presence: true
   validates :code, presence: true, length: { maximum: 50 }, uniqueness: true

--- a/app/views/stock_subjects/_form.html.erb
+++ b/app/views/stock_subjects/_form.html.erb
@@ -4,7 +4,7 @@
     <p><%= "#{int2term @subject.term}学期" %></p>
     <div class='modal-error-field'></div>
     <% if @present %>
-      <%= form_tag "/stock_subjects/#{@subject.id}", method: "delete", remote: true, class: "modal-form" do %>
+      <%= form_tag "/stock_subjects/#{@subject.subject_id}", method: "delete", remote: true, class: "modal-form" do %>
         <p>ストックから削除しますか？</p>
         <%= submit_tag "削除", class: "btn" %>
       <% end %>

--- a/db/migrate/20170317172859_create_stocked_logs.rb
+++ b/db/migrate/20170317172859_create_stocked_logs.rb
@@ -1,0 +1,15 @@
+class CreateStockedLogs < ActiveRecord::Migration[5.0]
+  def change
+    create_table :stocked_logs do |t|
+      t.string :uuid, null: false
+      t.references :subject, foreign_key: true
+      t.integer :week, null: false
+      t.string :periods, null: false
+
+      t.timestamps
+    end
+    add_index :stocked_logs, :uuid
+    add_index :stocked_logs, :week
+    add_index :stocked_logs, :periods
+  end
+end

--- a/db/migrate/20170317174452_add_index_to_summarized_subject.rb
+++ b/db/migrate/20170317174452_add_index_to_summarized_subject.rb
@@ -1,0 +1,7 @@
+class AddIndexToSummarizedSubject < ActiveRecord::Migration[5.0]
+  def change
+    add_index :summarized_subjects, :teacher_name
+    add_index :summarized_subjects, :place
+    add_index :summarized_subjects, :term
+  end
+end

--- a/db/migrate/20170317184632_add_column_to_stocked_log.rb
+++ b/db/migrate/20170317184632_add_column_to_stocked_log.rb
@@ -1,0 +1,5 @@
+class AddColumnToStockedLog < ActiveRecord::Migration[5.0]
+  def change
+    add_column :stocked_logs, :deleted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170317140159) do
+ActiveRecord::Schema.define(version: 20170317174452) do
 
   create_table "faculties", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",          null: false
@@ -18,6 +18,19 @@ ActiveRecord::Schema.define(version: 20170317140159) do
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
     t.string   "syllabus_code"
+  end
+
+  create_table "stocked_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "uuid",       null: false
+    t.integer  "subject_id"
+    t.integer  "week",       null: false
+    t.string   "periods",    null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["periods"], name: "index_stocked_logs_on_periods", using: :btree
+    t.index ["subject_id"], name: "index_stocked_logs_on_subject_id", using: :btree
+    t.index ["uuid"], name: "index_stocked_logs_on_uuid", using: :btree
+    t.index ["week"], name: "index_stocked_logs_on_week", using: :btree
   end
 
   create_table "subject_relationships", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -93,7 +106,10 @@ ActiveRecord::Schema.define(version: 20170317140159) do
     t.index ["mean_score"], name: "index_summarized_subjects_on_mean_score", using: :btree
     t.index ["name"], name: "index_summarized_subjects_on_name", using: :btree
     t.index ["number_of_students"], name: "index_summarized_subjects_on_number_of_students", using: :btree
+    t.index ["place"], name: "index_summarized_subjects_on_place", using: :btree
     t.index ["subject_id"], name: "index_summarized_subjects_on_subject_id", using: :btree
+    t.index ["teacher_name"], name: "index_summarized_subjects_on_teacher_name", using: :btree
+    t.index ["term"], name: "index_summarized_subjects_on_term", using: :btree
     t.index ["weighted_score"], name: "index_summarized_subjects_on_weighted_score", using: :btree
   end
 
@@ -129,6 +145,7 @@ ActiveRecord::Schema.define(version: 20170317140159) do
     t.index ["year"], name: "index_year_data_on_year", using: :btree
   end
 
+  add_foreign_key "stocked_logs", "subjects"
   add_foreign_key "subject_scores", "subjects"
   add_foreign_key "subjects", "faculties"
   add_foreign_key "summarized_subjects", "faculties"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170317174452) do
+ActiveRecord::Schema.define(version: 20170317184632) do
 
   create_table "faculties", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",          null: false
@@ -21,12 +21,13 @@ ActiveRecord::Schema.define(version: 20170317174452) do
   end
 
   create_table "stocked_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "uuid",       null: false
+    t.string   "uuid",                       null: false
     t.integer  "subject_id"
-    t.integer  "week",       null: false
-    t.string   "periods",    null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "week",                       null: false
+    t.string   "periods",                    null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "deleted",    default: false
     t.index ["periods"], name: "index_stocked_logs_on_periods", using: :btree
     t.index ["subject_id"], name: "index_stocked_logs_on_subject_id", using: :btree
     t.index ["uuid"], name: "index_stocked_logs_on_uuid", using: :btree

--- a/test/fixtures/stocked_logs.yml
+++ b/test/fixtures/stocked_logs.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  uuid: MyString
+  subject_id: 1
+  week: 1
+  periods: MyString
+
+two:
+  uuid: MyString
+  subject_id: 1
+  week: 1
+  periods: MyString

--- a/test/models/stocked_log_test.rb
+++ b/test/models/stocked_log_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class StockedLogTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要
stockのログを保存するようにした #26 

## やったこと
- これまでのCookieがpermanentじゃなかったから変更（faculty_checkboxは除く）
- CookieにUUIDを保存
- StockedLogのテーブルを作成
- stock時にrowの作成，unstock時に論理削除するようにした 

## memo
StockedLogは，[UUID, subject_id]でuniquenessになっている
同じsubject_idをもう一度stockした場合はUpdateされる