### PR TITLE
Change width of name cloumn in datatables

### DIFF
--- a/app/assets/javascripts/subjects.js
+++ b/app/assets/javascripts/subjects.js
@@ -81,9 +81,10 @@ function load_table() {
           "render":function (data) {
             var link = data.split("===")
             return '<a target="_blank" href="'+link[1]+'">'+link[0]+'</a>';
-          }
+          },
+          "width": "25%"
         },
-        { "data": "teacher_name", "orderSequence": [ "desc", "asc"] },
+        { "data": "teacher_name", "orderSequence": [ "desc", "asc"], "width": "15%" },
         { "data": "A", "orderSequence": [ "desc", "asc"] },
         { "data": "B", "orderSequence": [ "desc", "asc"] },
         { "data": "C", "orderSequence": [ "desc", "asc"] },


### PR DESCRIPTION
# 概要
DataTablesのUIをちょっと変更した

# なぜ
Edgeでみたときに，Stockボタンが消えてた．毎回＋オスのめんどいだろうから，変更

# なにした
name, teacher_nameのwidthを指定して，固定した．
これで直るはず（Windows確認できないからDeployするしかない．．．）