### PR TITLE
[fix] 重複してDataTablesが表示されるの直した

### DIFF
--- a/app/assets/javascripts/subjects.js
+++ b/app/assets/javascripts/subjects.js
@@ -22,6 +22,14 @@ var is_pc = (function(){
 })();
 
 function initialize_datatalbes(){
+  var table_tag = '' +
+  '<table id="subjects" class="table table-striped table-bordered subjects display responsive no-wrap">' +
+    '<thead class="datatables-thead">' +
+    '</thead>' +
+    '<tbody>' +
+    '</tbody>' +
+  '</table>';
+  
   if (getDevice == "sp"){
     var thead = "<tr>"+
     "<th>科目名</th>" +
@@ -46,9 +54,9 @@ function initialize_datatalbes(){
     "<th></th>" +
     "</tr>";
   }
-  if ($(".datatables-thead").find(".thead-data").length == 0){
-    $(".datatables-thead").append(thead);
-  }
+  $('#subjects_wrapper').remove();
+  $(".table-div").html(table_tag);
+  $(".datatables-thead").html(thead);
 }
 
 function load_table() {  

--- a/app/views/faculties/index.html.erb
+++ b/app/views/faculties/index.html.erb
@@ -37,12 +37,8 @@
   </p>
 </div>
 
-<table id="subjects" class="table table-striped table-bordered subjects display responsive no-wrap">
-  <thead class="datatables-thead">
-  </thead>
-  <tbody>
-  </tbody>
-</table>
+<div class="table-div">
+</div>
 
 <script>
   initialize_datatalbes();


### PR DESCRIPTION
# 概要
戻るをすると重複してDataTablesが表示されるのを直した #17
![syllabusplus](https://cloud.githubusercontent.com/assets/11977833/24333081/fcc8913a-128c-11e7-9339-ae2274965653.png)

# 原因
`<table id='subjects'>`が一度，DataTablesによって，`subjects_wrapper`に書き換えられて，テーブルが作成される．
その中に`<table id='subjects'>`が含まれているのだが，戻るをした際に，`subjects_wrapper`の中の`<table id='subjects'>`にさらに`subjects_wrapper`に書き換えられる．
これを繰り返す．．．ことによって，重複して表示される．

# やったこと
一度，`subjects_wrapper`を削除して，`<table id='subjects'>`を再度構築することで重複を防いだ