### PR TITLE
[fix] 最長マッチングしてたのを最短マッチングに変えた

### DIFF
--- a/lib/tasks/update_syllabus_data.rb
+++ b/lib/tasks/update_syllabus_data.rb
@@ -41,10 +41,10 @@ class BatchUpdateSyllabusData
     ["テキスト", "参考文献"].each do |cat|
       if table_hash[cat].present?
         table_hash[cat].css('tbody > tr').each do |c|
-          keyword = (c.text.match(/『(.+)』/) || [])[-1]
-          if keyword
-            SyllabusDatum.create(subject_id: subject.subject_id, tag: cat, category: nil, value: keyword)
-            # p "#{subject.subject_id}, #{cat}, , #{keyword}"
+          keywords = (c.text.scan(/『(.+?)』/) || [])
+          keywords.each do |keyword|
+            SyllabusDatum.create(subject_id: subject.subject_id, tag: cat, category: nil, value: keyword[0])
+            # p "#{subject.subject_id}, #{cat}, , #{keyword[0]}"
           end
         end
       end


### PR DESCRIPTION
# 概要
最長マッチングしてたのを最短マッチングに変えた
一つのタグに複数の書籍が書いてあった場合にうまくマッチしなかった
例：https://syllabus.doshisha.ac.jp/html/2017/0306/10306955109.html