### PR TITLE
Add page for popularity subject search

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -33,6 +33,18 @@ class StaticPagesController < ApplicationController
     else
       redirect_to contact_url, :alert => "内容が記入されていません．"
     end
-    
+  end
+  
+  def popularity
+    limit_num = 20
+    @faculties = Faculty.all
+    if faculty_id = params["faculty_id"]
+      ordered = StockedLog.joins(:summarized_subject).where("faculty_id = #{faculty_id}").group(:subject_id).order('count_subject_id desc').count('subject_id')
+    else
+      ordered = StockedLog.group(:subject_id).order('count_subject_id desc').count('subject_id')
+    end
+    keys = ordered.keys
+    @values = ordered.values
+    @subjects = SummarizedSubject.where(subject_id: keys).sort_by {|p| keys.index(p.subject_id) }
   end
 end

--- a/app/views/static_pages/popularity.html.erb
+++ b/app/views/static_pages/popularity.html.erb
@@ -1,0 +1,35 @@
+<h1>人気科目</h1>
+<h3>Stockされた回数の多い科目<%= (faculty_id = params['faculty_id']) ? " (#{@faculties.find(faculty_id).name})" : "" %></h3>
+
+<style type="text/css">
+td, th {
+padding: 10px 20px;
+}
+
+</style>
+
+<%= form_tag(popularity_path, method: "get") do %>
+  絞り込み検索：<%= select_tag "faculty_id", options_from_collection_for_select(@faculties, "id", "name") %>
+  <%= submit_tag("検索") %>
+<% end %>
+<p><%= button_to "リセット", popularity_path, method: "get" %><p>
+
+
+<table>
+  <thead>
+    <tr>
+      <th>科目</th><th>id</th><th>平均評点</th><th>学部</th><th>回数</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @subjects.each_with_index do |subject, i| %>
+      <tr>
+        <td><%= link_to subject.name, subject, target: :_blank %></td>
+        <td><%= subject.subject_id %></td>
+        <td><%= subject.mean_score %></td>
+        <td><%= (name = @faculties.find(subject.faculty_id).name).include?('（') ? name.match(/（(.+)）/)[1] : name %></td>
+        <td><%= @values[i] %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get 'q_and_a' => 'static_pages#q_and_a'
   get 'contact' => 'static_pages#contact'
   post 'contact' => 'static_pages#post_contact'
+  get 'popularity' => 'static_pages#popularity'
   
   resources :faculties, only: [:index, :show] do
     collection do


### PR DESCRIPTION
# 概要
雑に人気科目検索画面を作った

# WHY
いつもコンソールにログインしてみてたが，めんどくさいので，動線設置せずページ作ってみた
誰かがたどり着けても問題ないので普通に公開する

割りと雑に作ったので検索の度に`popularity_path`にgetを投げて，パラメータで処理している
（のでselecterが初期化されて常に神学部になっている）
Ajaxとかでやるべきところなので，ユーザに提供するのであればちゃんとしよう
<img width="864" alt="syllabusplus" src="https://cloud.githubusercontent.com/assets/11977833/24559826/1b7595a0-167b-11e7-9d19-c29409b97f41.png">
